### PR TITLE
release v1.0.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,5 +34,13 @@ archives:
       {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
 release:
   mode: keep-existing
+  header: |
+    ## changes from lassie
+
+    - ripped out bitswap and graphsync. http only, no negotiation overhead
+    - switched from legacy ipni to delegated routing v1 api for provider discovery
+    - added frontier traversal: when a provider returns an incomplete car, we continue fetching missing blocks from other providers. efficiently handles the case where content is split across multiple nodes
+    - full client-side implementation of the trustless gateway spec, including entity-bytes range requests
+    - streaming extraction (--extract): writes files directly to disk as blocks arrive. no intermediate car, no seeking, no car extract required. handles chunked files, deduplication, and out-of-order block arrival
 changelog:
   disable: true

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.25.0-rc4"
+  "version": "v1.0.0"
 }


### PR DESCRIPTION
somewhat cheeky (by golang standards) 1.0, however this is a pretty big break from the original codebase so I think it's not entirely inappropriate

sheltie ready for real-world testing!